### PR TITLE
Limit user to 5 uploads

### DIFF
--- a/app/controllers/uploads.js
+++ b/app/controllers/uploads.js
@@ -24,6 +24,13 @@ const show = (req, res, next) => {
 };
 
 const create = (req, res, next) => {
+  let numUploads = req.currentUser.uploads.length;
+  if (numUploads >= 5) {
+    res.sendStatus(400);
+    res.send('Maximum number of uploads already reached.');
+    next();
+  }
+
   uploader.awsUpload(req.file.buffer)
   .then((response) => {
     return {


### PR DESCRIPTION
- At beginning of uploads#create, validate the request by checking the
  length of the current user's `uploads` array
- If 5 or more, send a 400 Bad Request response

We should still probably perform this validation on the front end
as well, so that the user can be given a custom response to this
failure condition.
