### PR TITLE
On sign-in, returned user has populated uploads

### DIFF
--- a/app/controllers/users.js
+++ b/app/controllers/users.js
@@ -74,7 +74,16 @@ const signin = (req, res, next) => {
   let credentials = req.body.credentials;
   let search = { email: credentials.email };
   User.findOne(search
-  ).then(user =>
+  )
+  .populate('uploads')
+  .exec(function (err, user) {
+    if (err) {
+      next(err);
+    } else {
+      return user;
+    }
+  })
+  .then(user =>
     user ? user.comparePassword(credentials.password) :
           Promise.reject(new HttpError(404))
   ).then(user =>
@@ -82,7 +91,8 @@ const signin = (req, res, next) => {
       user.token = token;
       return user.save();
     })
-  ).then(user => {
+  )
+  .then(user => {
     user = user.toObject();
     delete user.passwordDigest;
     user.token = encodeToken(user.token);


### PR DESCRIPTION
- On users#signin, the returned user object has the references
  in its `uploads` field populated with the upload documents to
  which they refer
