### PR TITLE
Validate file size and type

### DIFF
--- a/scripts/sign-in.sh
+++ b/scripts/sign-in.sh
@@ -4,7 +4,7 @@ curl --include --request POST http://localhost:3000/sign-in \
   --header "Content-Type: application/json" \
   --data '{
     "credentials": {
-      "email": "1@1.com",
+      "email": "an@example.com",
       "password": "1"
     }
   }'
@@ -14,7 +14,7 @@ curl --include --request POST http://localhost:3000/sign-in \
     --header "Content-Type: application/json" \
     --data '{
       "credentials": {
-        "email": "1@1.com",
+        "email": "an@example.com",
         "password": "1"
       }
     }'

--- a/scripts/sign-up.sh
+++ b/scripts/sign-up.sh
@@ -6,9 +6,10 @@ curl --include --request POST http://localhost:3000/sign-up \
   --header "Content-Type: application/json" \
   --data '{
     "credentials": {
-      "email": "an@example.email",
-      "password": "an example password",
-      "password_confirmation": "an example password"
+      "userName": "example",
+      "email": "an@example.com",
+      "password": "1",
+      "password_confirmation": "1"
     }
   }'
 
@@ -18,7 +19,8 @@ curl --include --request POST https://desert-island-api.herokuapp.com/sign-up \
   --header "Content-Type: application/json" \
   --data '{
     "credentials": {
-      "email": "1@1.com",
+      "userName": "example",
+      "email": "an@example.com",
       "password": "1",
       "password_confirmation": "1"
     }


### PR DESCRIPTION
- When the create action is fired on the Uploads controller, the size and type of the file is validated before proceeding with the file upload.
- If the file is not of a supported type, or exceeds 10MB in size, a '403 Forbidden' response is sent.
- This pull request also includes updated curl scripts for sign-in and sign-up to reflect the new userName field we added yesterday.
